### PR TITLE
Added external: true (removed by accident during commit 10 januari 2022)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ networks:
   proxy: # network name is used by RAP4 script to make student prototype container accessible via traefik ingress
     external: true # must be external to prevent prefix with folder name
   rap_db: # network name is used by RAP4 script to let student prototype container connect to database
+    external: true # must be external to prevent prefix with folder name
   testchannel: # network testchannel is used by the test-elf to run API-tests on rap4
 
 services:


### PR DESCRIPTION
Another option is to set the name to prevent the prefix. The networks don't have to pre-exist and are created when container is started.

name: proxy # must be set to prevent prefix with folder name
name: rap_db # must be set to prevent prefix with folder name

Closes #217 