### PR TITLE
Added patch and delete permissions, renamed resources

### DIFF
--- a/deployment/resources/elevated-rights-service-account.yaml
+++ b/deployment/resources/elevated-rights-service-account.yaml
@@ -3,31 +3,31 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rap4svcaccount
+  name: elevated-rights-service-account
   namespace: rap
 ---
 # # Role that is used to give a pod elevated rights in the Kubernetes cluster
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: modify-pods
+  name: elevated-rights-role
   namespace: rap
 rules:
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["create", "delete", "get", "watch", "list"]
+    verbs: ["get", "watch", "list", "create", "delete", "patch"]
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
-    verbs: ["get", "watch", "list", "create"]
+    verbs: ["get", "watch", "list", "create", "delete", "patch"]
   - apiGroups: [""]
     resources: ["services"]
-    verbs: ["get", "watch", "list", "create"]
+    verbs: ["get", "watch", "list", "create", "delete", "patch"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "watch", "list", "create"]
+    verbs: ["get", "watch", "list", "create", "delete", "patch"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["get", "watch", "list", "create"]
+    verbs: ["get", "watch", "list", "create", "delete", "patch"]
 
 ---
 # # Role that is used to give a pod elevated rights in the Kubernetes cluster
@@ -35,13 +35,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: modifypods
+  name: elevated-rights-rolebinding
   namespace: rap
 subjects:
   - kind: ServiceAccount
-    name: rap4svcaccount
+    name: elevated-rights-service-account
     namespace: rap
 roleRef:
   kind: Role
-  name: modify-pods
+  name: elevated-rights-role
   apiGroup: rbac.authorization.k8s.io

--- a/deployment/resources/rap-deployment.yaml
+++ b/deployment/resources/rap-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       labels:
         app: rap
     spec:
-      serviceAccountName: rap4svcaccount
+      serviceAccountName: elevated-rights-service-account
       containers:
         - image: ampersandrap.azurecr.io/ampersand-rap:2023-22-03-v5
           name: ampersand-rap


### PR DESCRIPTION
Bug fix: service account didn't have rights to overwrite an existing Kubernetes resource.
Changed names to be more in line with other resources.